### PR TITLE
Add matrix to GitHub workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,3 +45,4 @@ jobs:
         uses: codecov/codecov-action@v1
         with:
           file: ./coverage.out
+          flags: ${{ runner.os }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,14 @@ on:
 
 jobs:
   ci-build:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go-version: [1.15]
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        shell: bash
     steps:
       - uses: actions/checkout@v2
         with:
@@ -21,7 +28,7 @@ jobs:
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
       - uses: actions/setup-go@v2
         with:
-          go-version: 1.15
+          go-version: ${{ matrix.go-version }}
       - name: Build
         run: make ci
       - name: Upload coverage


### PR DESCRIPTION
## Why

It is good to ensure that the build works on different environments.
Solves https://github.com/golang-templates/seed/issues/68

## What

Refine the GitHub workflow to work with multiple versions of OS and Go.