### PR TITLE
trigger build when pushed to the main branch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,8 +3,8 @@ name: build
 on:
   push:
     branches: 
-      - master
       - main 
+      - master
   pull_request:
     branches:
       - '*'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: 
       - master
+      - main 
   pull_request:
     branches:
       - '*'

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -2,10 +2,10 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ master, main ]
+    branches: [ main, master ]
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [ master, main ]
+    branches: [ main, master ]
   schedule:
     - cron: '11 0 * * 5'
 

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -2,10 +2,10 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ master ]
+    branches: [ master, main ]
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [ master ]
+    branches: [ master, main ]
   schedule:
     - cron: '11 0 * * 5'
 


### PR DESCRIPTION
This is really a trivial feature I have to admit, but  I really love this project and hope to make it better ❤️ 


Since **the default branch for newly-created repositories is now main on Github**, we as a GitHub template would be better if we also follow the change:

- https://github.com/github/renaming
- https://github.blog/changelog/2020-10-01-the-default-branch-for-newly-created-repositories-is-now-main/

Once this pull request is merged, any maintain can rename our `master` branch to `main` very easily:

- https://github.com/github/renaming#renaming-existing-branches