### PR TITLE
Release 0.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased](https://github.com/golang-templates/seed/compare/v0.16.2...HEAD)
+## [Unreleased](https://github.com/golang-templates/seed/compare/v0.17.0...HEAD)
 
-## [0.16.2](https://github.com/golang-templates/seed/releases/tag/v0.16.2)
+## [0.17.0](https://github.com/golang-templates/seed/releases/tag/v0.17.0)
 
 ### Changed
 
 - Update golangci-lint configuration. ([#222](https://github.com/golang-templates/seed/pull/222))
+- Update Make targets. ([#224](https://github.com/golang-templates/seed/pull/224))
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased](https://github.com/golang-templates/seed/compare/v0.16.1...HEAD)
+## [Unreleased](https://github.com/golang-templates/seed/compare/v0.16.2...HEAD)
+
+## [0.16.2](https://github.com/golang-templates/seed/releases/tag/v0.16.2)
+
+### Changed
+
+- Update golangci-lint configuration. ([#222](https://github.com/golang-templates/seed/pull/222))
 
 ### Removed
 


### PR DESCRIPTION
### Changed

- Update golangci-lint configuration. ([#222](https://github.com/golang-templates/seed/pull/222))
- Update Make targets. ([#224](https://github.com/golang-templates/seed/pull/224))

### Removed

- Remove [go-acc](https://github.com/ory/go-acc) and use `coverpkg` flag instead. ([#221](https://github.com/golang-templates/seed/pull/221))