### PR TITLE
Remove gomnd linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -34,7 +34,6 @@ linters:
     - gofumpt
     - goimports
     - revive
-    - gomnd
     - goprintffuncname
     - gosec
     - gosimple


### PR DESCRIPTION
Remove https://github.com/tommy-muehle/go-mnd linter as it can be seen as being more annoying than helpful.