### PR TITLE
Adjust Build Status badge to new shields.io API

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Go Reference](https://pkg.go.dev/badge/github.com/golang-templates/seed.svg)](https://pkg.go.dev/github.com/golang-templates/seed)
 [![go.mod](https://img.shields.io/github/go-mod/go-version/golang-templates/seed)](go.mod)
 [![LICENSE](https://img.shields.io/github/license/golang-templates/seed)](LICENSE)
-[![Build Status](https://img.shields.io/github/workflow/status/golang-templates/seed/build)](https://github.com/golang-templates/seed/actions?query=workflow%3Abuild+branch%3Amain)
+[![Build Status](https://img.shields.io/github/actions/workflow/status/golang-templates/seed/build.yml?branch=main)](https://github.com/golang-templates/seed/actions?query=workflow%3Abuild+branch%3Amain)
 [![Go Report Card](https://goreportcard.com/badge/github.com/golang-templates/seed)](https://goreportcard.com/report/github.com/golang-templates/seed)
 [![Codecov](https://codecov.io/gh/golang-templates/seed/branch/main/graph/badge.svg)](https://codecov.io/gh/golang-templates/seed)
 


### PR DESCRIPTION
## Why

<!-- Why this pull request was created?
     Explain the problem that this pull request is trying to solve. -->

The owners of the shield badges changed the way of serving badges for GitHub workflows. The migration steps are described in https://github.com/badges/shields/issues/8671.

## What

<!-- What does this pull request contain?
     Explain what is this pull request changing. -->

The badge URL is adjusted to the new shields.io API.
