### PR TITLE
Release 0.19.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.21'
+          go-version: '1.22'
 
       - name: Build
         run: make ci

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.21'
+          go-version: '1.22'
 
       - run: make inst
 

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -21,5 +21,10 @@
     "go.lintTool": "golangci-lint",
     "go.lintFlags": [
         "--fast"
-    ]
+    ],
+    "[go][go.mod]": {
+        "editor.codeActionsOnSave": {
+            "source.organizeImports": "explicit"
+        }
+    }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/golang-templates/seed/compare/v0.19.0...HEAD)
 
-## [0.18.0](https://github.com/golang-templates/seed/releases/tag/v0.19.0)
+## [0.19.0](https://github.com/golang-templates/seed/releases/tag/v0.19.0)
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased](https://github.com/golang-templates/seed/compare/v0.18.0...HEAD)
+## [Unreleased](https://github.com/golang-templates/seed/compare/v0.19.0...HEAD)
+
+## [0.18.0](https://github.com/golang-templates/seed/releases/tag/v0.19.0)
+
+### Added
+
+- Add `sqlclosecheck` linter. ([#235](https://github.com/golang-templates/seed/pull/235))
+
+### Changed
+
+- Change license to CC0-1.0. ([#241](https://github.com/golang-templates/seed/pull/241))
+- Update Codecov instructions for v4. ([#289](https://github.com/golang-templates/seed/pull/289))
 
 ### Fixed
 
@@ -105,3 +116,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update [.golangci.yml](https://github.com/golang-templates/seed/blob/v0.14.0/.golangci.yml). ([#127](https://github.com/golang-templates/seed/pull/127))
 - Update [GoReleaser](https://github.com/goreleaser/goreleaser) to [0.162.0](https://github.com/goreleaser/goreleaser/releases/tag/v0.162.0). ([#126](https://github.com/golang-templates/seed/pull/126))
 - Update [golangci-lint](https://github.com/golangci/golangci-lint) to [1.39.0](https://github.com/golangci/golangci-lint/releases/tag/v1.39.0). ([#125](https://github.com/golang-templates/seed/pull/125))
+
+<!-- markdownlint-configure-file
+MD024:
+  # Only check sibling headings
+  siblings_only: true
+-->

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/golang-templates/seed
 
-go 1.21
+go 1.22

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -1,6 +1,6 @@
 module github.com/golang-templates/seed/build
 
-go 1.21
+go 1.22
 
 require (
 	github.com/client9/misspell v0.3.4


### PR DESCRIPTION
### Added

- Add `sqlclosecheck` linter. ([#235](https://github.com/golang-templates/seed/pull/235))

### Changed

- Change license to CC0-1.0. ([#241](https://github.com/golang-templates/seed/pull/241))
- Update Codecov instructions for v4. ([#289](https://github.com/golang-templates/seed/pull/289))

### Fixed

- Fix `inst` Make target for Go 1.21. ([#269](https://github.com/golang-templates/seed/pull/269))