### PR TITLE
Support for GoReleaser 2.0.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,7 @@
 name: build
 
 on:
-  push: 
+  push:
     branches: [ main ]
   pull_request:
     branches: [ main ]
@@ -32,7 +32,7 @@ jobs:
           name: coverage-${{ matrix.os }}
           path: coverage.*
 
-      - run: goreleaser release --rm-dist --snapshot
+      - run: goreleaser release --clean --snapshot
         if: ${{ runner.os == 'Linux' }}
 
       - name: Upload dist

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,3 +1,5 @@
+version: 2
+
 before:
   hooks:
     - go mod download
@@ -34,4 +36,4 @@ release:
   prerelease: auto
   mode: append
 changelog:
-  skip: true
+  disable: true

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -8,7 +8,7 @@ replace go.opentelemetry.io/otel/exporters/otlp/internal v0.20.1 => go.opentelem
 require (
 	github.com/client9/misspell v0.3.4
 	github.com/golangci/golangci-lint v1.58.2
-	github.com/goreleaser/goreleaser v2.0.0
+	github.com/goreleaser/goreleaser/v2 v2.0.0
 	golang.org/x/vuln v1.1.1
 )
 

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -8,7 +8,7 @@ replace go.opentelemetry.io/otel/exporters/otlp/internal v0.20.1 => go.opentelem
 require (
 	github.com/client9/misspell v0.3.4
 	github.com/golangci/golangci-lint v1.58.2
-	github.com/goreleaser/goreleaser v1.26.2
+	github.com/goreleaser/goreleaser v2.0.0
 	golang.org/x/vuln v1.1.1
 )
 

--- a/tools/go.sum
+++ b/tools/go.sum
@@ -545,8 +545,8 @@ github.com/goreleaser/chglog v0.6.1 h1:NZKiX8l0FTQPRzBgKST7knvNZmZ04f7PEGkN2wInf
 github.com/goreleaser/chglog v0.6.1/go.mod h1:Bnnfo07jMZkaAb0uRNASMZyOsX6ROW6X1qbXqN3guUo=
 github.com/goreleaser/fileglob v1.3.0 h1:/X6J7U8lbDpQtBvGcwwPS6OpzkNVlVEsFUVRx9+k+7I=
 github.com/goreleaser/fileglob v1.3.0/go.mod h1:Jx6BoXv3mbYkEzwm9THo7xbr5egkAraxkGorbJb4RxU=
-github.com/goreleaser/goreleaser v1.26.2 h1:1iY1HaXtRiMTrwy6KE1sNjkRjsjMi+9l0k6WUX8GpWw=
-github.com/goreleaser/goreleaser v1.26.2/go.mod h1:mHi6zr6fuuOh5eHdWWgyo/N8BWED5WEVtb/4GETc9jQ=
+github.com/goreleaser/goreleaser/v2 v2.0.0 h1:TxH7v+rYsQ+e4CQDMmdBFnVzxuTbBJRwsLXeCSkOREU=
+github.com/goreleaser/goreleaser/v2 v2.0.0/go.mod h1:eit+2+u8uJLgBtuEMITPaQHwO55amhR089eFkbWi3s0=
 github.com/goreleaser/nfpm/v2 v2.37.1 h1:RUmeEt8OlEVeSzKRrO5Vl5qVWCtUwx4j9uivGuRo5fw=
 github.com/goreleaser/nfpm/v2 v2.37.1/go.mod h1:q8+sZXFqn106/eGw+9V+I8+izFxZ/sJjrhwmEUxXhUg=
 github.com/gorilla/mux v1.8.1 h1:TuBL49tXwgrFYWhqrNgrUNEY92u81SPhu7sTdzQEiWY=

--- a/tools/tools.go
+++ b/tools/tools.go
@@ -10,6 +10,6 @@ package tools
 import (
 	_ "github.com/client9/misspell/cmd/misspell"
 	_ "github.com/golangci/golangci-lint/cmd/golangci-lint"
-	_ "github.com/goreleaser/goreleaser"
+	_ "github.com/goreleaser/goreleaser/v2"
 	_ "golang.org/x/vuln/cmd/govulncheck"
 )


### PR DESCRIPTION
Fixes https://github.com/golang-templates/seed/issues/318

This PR aims to address the issue with a recent breaking change to goreleaser as described here https://github.com/goreleaser/goreleaser/releases/tag/v2.0.0.

