### PR TITLE
Release 0.21.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased](https://github.com/golang-templates/seed/compare/v0.20.0...HEAD)
+## [Unreleased](https://github.com/golang-templates/seed/compare/v0.21.0...HEAD)
+
+## [0.21.0](https://github.com/golang-templates/seed/releases/tag/v0.21.0)
+
+### Added
+
+- Apply security best practices. ([#359](https://github.com/golang-templates/seed/pull/359))
+
+### Changed
+
+- Use `go tool` instead of blank imports in `tools.go`. ([#364](https://github.com/golang-templates/seed/pull/364))
+- Update `golangci-lint` configuration and do not print Make target names. ([#358](https://github.com/golang-templates/seed/pull/358))
 
 ## [0.20.0](https://github.com/golang-templates/seed/releases/tag/v0.20.0)
 


### PR DESCRIPTION
### Added

- Apply security best practices. ([#359](https://github.com/golang-templates/seed/pull/359))

### Changed

- Use `go tool` instead of blank imports in `tools.go`. ([#364](https://github.com/golang-templates/seed/pull/364))
- Update `golangci-lint` configuration and do not print Make target names. ([#358](https://github.com/golang-templates/seed/pull/358))