### PR TITLE
Add run Make target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/golang-templates/seed/compare/v0.21.0...HEAD)
 
+### Added
+
+- Add `run` target which runs `go run`. ([#376](https://github.com/golang-templates/seed/pull/376))
+
 ## [0.21.0](https://github.com/golang-templates/seed/releases/tag/v0.21.0)
 
 ### Added

--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,10 @@ clean: ## remove files created during build pipeline
 	rm -f '"$(shell go env GOCACHE)/../golangci-lint"'
 	go clean -i -cache -testcache -modcache -fuzzcache -x
 
+.PHONY: run
+run: ## Run the Go application
+	go run main.go
+
 .PHONY: mod
 mod: ## go mod tidy
 	go mod tidy

--- a/Makefile
+++ b/Makefile
@@ -26,8 +26,8 @@ clean: ## remove files created during build pipeline
 	go clean -i -cache -testcache -modcache -fuzzcache -x
 
 .PHONY: run
-run: ## Run the Go application
-	go run main.go
+run: ## go run
+	go run .
 
 .PHONY: mod
 mod: ## go mod tidy


### PR DESCRIPTION
This PR adds a make run target to the Makefile, making it easier to run the Go application with a single command.

**Changes Introduced:**
Added run target to Makefile:

```
.PHONY: run
run: ## Run the Go application
    go run main.go

```
**Motivation**:
The Makefile currently provides targets for building, testing, and linting but lacks a command to run the application. This addition improves usability by allowing developers to start the application without manually using `go run` .

**How to Test:**
1. Pull the branch and checkout locally.
2. Run the following command:
    `make run`
    
Related Issue:
Fixes [#375 ](https://github.com/golang-templates/seed/issues/375)

Notes:

- Let me know if any modifications are needed!
- Happy to make further improvements if required. 🚀

