### PR TITLE
Update GoReleaser archive configuration

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -15,7 +15,7 @@ builds:
 archives:
   - format_overrides:
       - goos: windows
-        format: zip
+        formats: [zip]
 dockers:
   - image_templates:
     - "ghcr.io/golang-templates/seed:latest"


### PR DESCRIPTION
# PR Summary
This small PR updates the GoReleaser configuration to resolve the following warning which you can find in the [CI logs](https://github.com/golang-templates/seed/actions/runs/15555225201/job/43794255984#step:5:68): 
```
DEPRECATED: archives.format_overrides.format should not be used anymore, check https://goreleaser.com/deprecations#archivesformat_overridesformat for more info
```